### PR TITLE
Using needles for http/s sanity

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jexcel": "^3.4.4",
     "js-yaml": "^3.13.1",
     "material-design-icons": "^3.0.1",
+    "needle": "^2.5.0",
     "papaparse": "^5.1.0",
     "path": "^0.12.7",
     "python-shell": "^1.0.8",

--- a/workbench_desktop.yml
+++ b/workbench_desktop.yml
@@ -8,3 +8,10 @@ media_use_tid: 17
 content_type: islandora_object
 drupal_filesystem: "fedora://"
 id_field: id
+media_types:
+ - file: ['tif', 'tiff', 'jp2', 'zip', 'tar']
+ - document: ['pdf', 'doc', 'docx', 'ppt', 'pptx']
+ - image: ['png', 'gif', 'jpg', 'jpeg']
+ - audio: ['mp3', 'wav', 'aac']
+ - video: ['mp4']
+ - extracted_text: ['txt']


### PR DESCRIPTION
Resolves https://github.com/mjordan/islandora_workbench_desktop/issues/17

Uses an http library called needles that'll do things like follow redirects and automatically select the underlying http or https libs based on the URL that's provided.